### PR TITLE
Un-pin requests version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setup(
         license="MIT License",
         author="flrngel",
         author_email="flrngel@gmail.com",
-        install_requires=["requests==2.18.1"],
+        install_requires=["requests"],
         packages=find_packages())


### PR DESCRIPTION
The version of the requests library in setup.py is pinned to verrsion 2.18.1, which causes problems in projects that require newer versions of requests

Since metabase-py uses requests in the most straight-forward way, I'd suggest to remove that.