### PR TITLE
Be compatible with HTTP 202 streaming response

### DIFF
--- a/metabase/metabase.py
+++ b/metabase/metabase.py
@@ -27,13 +27,13 @@ class Metabase(object):
         return self.session_header()
 
     def fetch_header(self, r):
-        if r.status_code == 200:
+        if r.status_code == 200 or r.status_code == 202:
             return True
         else:
             return False
 
     def fetch_body(self, r):
-        if r.status_code == 200:
+        if r.status_code == 200 or r.status_code == 202:
             return True, r.json()
         else:
             return False, None


### PR DESCRIPTION
Metabase is introducing new mechanism to its API. 
It's called streaming API and it will enable to return HTTP 202 (instead of HTTP 200) code and a status token, which later can be used to check if particular async operation was a success, or threw an error. 
The issue where this initiative started: https://github.com/metabase/metabase/pull/11726
Some sort of very short info in the docs: https://github.com/metabase/metabase/wiki/Metabase-REST-API-Patterns

The current situation in version v0.35.3 is such that API endpoints used by this python library return 202 code, but the same JSON body as before. Even for operations such as creation of new card, where I can see that some processing is done in the server, the return value is same as before.

This simple PR accepts http 202 as an OK return code. We're currently working with this library to create a metabase based ETL/analytics tool, and will be paying attention to further developments here.  Shall Metabase API introduce returning the `_status`  token, we'll implement it.

So - please merge this because otherwise this library does not work with Metabase 0.35.3. 