### PR TITLE
fix: /api not being added to endpoint kwarg

### DIFF
--- a/metabase/metabase.py
+++ b/metabase/metabase.py
@@ -7,7 +7,7 @@ class Metabase(object):
 
     def __init__(self, *args, endpoint=None, email=None,
                  password=None, session=None, **kwargs):
-        self.endpoint = endpoint or os.getenv('METABASE_ENDPOINT') + '/api'
+        self.endpoint = (endpoint or os.getenv('METABASE_ENDPOINT')) + '/api'
         self.email = email or os.getenv('METABASE_AUTH_EMAIL')
         self.password = password or os.getenv('METABASE_AUTH_PASSWORD')
         self.session = session or os.getenv('METABASE_SESSION')


### PR DESCRIPTION
wrapped self.endpoint in parenthesis, this fixs a minor
bug where self.endpoint was being evaluated as:

kwarg or (environment variable + /api)

I believe this is a potential cause of #7 

